### PR TITLE
Publish to Docker Hub using GitHub Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
+  REGISTRY: docker.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
@@ -58,8 +58,8 @@ jobs:
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action


### PR DESCRIPTION
Related to #1

Update Docker GitHub Actions workflow to push container builds to Docker Hub.

* Change the `REGISTRY` environment variable to `docker.io`.
* Update the `Log into registry` step to use Docker Hub credentials.
* Use `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets for Docker Hub login.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rikvisser-tech/easy-icecast2/pull/2?shareId=21bfab86-902b-4ce4-b72a-24ecfc81e571).