### PR TITLE
Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Publish Docker image
+name: Publish Docker image to Docker Hub
 
 on:
   release:
@@ -51,6 +51,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: rikvisser/easy-icecast2
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
This pull request includes updates to the Docker image publishing workflow. The changes improve the clarity of the workflow name and specify a fixed Docker image name for artifact attestation.

Improvements to Docker publishing workflow:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L10-R10): Updated the workflow name to "Publish Docker image to Docker Hub" for better clarity.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L54-R54): Changed the `subject-name` in the artifact attestation step to use a fixed Docker image name `rikvisser/easy-icecast2`.