### PR TITLE
Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,6 +51,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: docker.io/rikvisser/easy-icecast2
+          subject-name: hub.docker.com/r/rikvisser/easy-icecast2
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/docker-publish.yml` file. The change updates the `subject-name` field to use the correct Docker Hub URL for the `easy-icecast2` image.

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L54-R54): Updated `subject-name` to `hub.docker.com/r/rikvisser/easy-icecast2` to reflect the correct Docker Hub URL.