### PR TITLE
Add GitHub Packages workflow

### DIFF
--- a/.github/workflows/publish-to-github-packages.yml
+++ b/.github/workflows/publish-to-github-packages.yml
@@ -1,0 +1,40 @@
+name: Publish Docker image to GitHub Packages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_github_packages:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/easy-icecast2
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ The Icecast2 server can be configured using environment variables. The following
 
 These environment variables can be set in the `docker-compose.yml` file.
 
+## Publishing to GitHub Packages
+
+To publish the Docker image to GitHub Packages, follow these steps:
+
+1. Create a new release on GitHub.
+2. The GitHub Actions workflow will automatically build and push the Docker image to GitHub Packages.
+
+You can find the Docker image in the GitHub Packages section of your repository.
+
 ## Contributing
 
 Contributions are welcome! If you have any suggestions, bug reports, or feature requests, please open an issue or submit a pull request.


### PR DESCRIPTION
Fixes #10

Add a new GitHub Actions workflow for publishing Docker images to GitHub Packages.

* **New Workflow**: Create `.github/workflows/publish-to-github-packages.yml` to handle publishing Docker images to GitHub Packages on release events.
  - Trigger the workflow on release events.
  - Add steps for checking out the repo, logging into GitHub Packages, extracting metadata, and building and pushing the Docker image.

* **Documentation**: Update `README.md` to include instructions for publishing Docker images to GitHub Packages.
  - Add a new section "Publishing to GitHub Packages" with steps to create a new release and find the Docker image in the GitHub Packages section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rikvisser-tech/easy-icecast2/pull/13?shareId=22ddd750-e16e-4d1f-8dc4-aca11c34106d).